### PR TITLE
Add search UTs

### DIFF
--- a/proj/custom-tools-tests/custom-tools-tests.csproj
+++ b/proj/custom-tools-tests/custom-tools-tests.csproj
@@ -51,7 +51,13 @@
 	<Compile Include="..\..\src\DataStructures\test\ArrangementUnitTests.cs" />
     <Compile Include="..\..\src\DataStructures\test\BinaryHeapComponentTests.cs" />
     <Compile Include="..\..\src\DataStructures\test\ExtensionsUnitTests.cs" />
+	<Compile Include="..\..\src\Search\test\BidirectionalSearchUnitTests.cs" />
+	<Compile Include="..\..\src\Search\test\BreadthFirstSearchUnitTests.cs" />
+	<Compile Include="..\..\src\Search\test\DepthFirstSearchUnitTests.cs" />
+	<Compile Include="..\..\src\Search\test\LeastWeightPathSearchUnitTests.cs" />
 	<Compile Include="..\..\src\Search\test\SearchComponentTests.cs" />
+	<Compile Include="..\..\src\Search\test\SearchTestHelpers.cs" />
+	<Compile Include="..\..\src\Search\test\TestGraphs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Search/BidirectionalSearch.cs
+++ b/src/Search/BidirectionalSearch.cs
@@ -60,9 +60,12 @@ namespace Tools.Algorithms.Search {
 
 		public IEnumerable<T> FindPath(T start, T end)
 		{
-			if (start == null || end == null)
-				return new T[] { };
-			else if (start.Equals(end))
+			if (start == null)
+				throw new ArgumentNullException("start");
+			if (end == null)
+				throw new ArgumentNullException("end");
+
+			if (start.Equals(end))
 				return new T[] { start };
 
 			var startNode = new PathNode<T>(start);
@@ -101,6 +104,9 @@ namespace Tools.Algorithms.Search {
 				foreach (T child in GetForwardChildren(forwardNode.State))
 				{
 					var childNode = new PathNode<T>(child, forwardNode);
+					if (childNode.Equals(end))
+						return childNode.GetPath();
+
 					if (!explored.Contains(childNode) && !forwardFrontier.Contains(childNode))
 						forwardFrontier.Enqueue(childNode);
 				}
@@ -114,6 +120,15 @@ namespace Tools.Algorithms.Search {
 				foreach (T child in GetReverseChildren(reverseNode.State))
 				{
 					var childNode = new PathNode<T>(child, reverseNode);
+					if (childNode.Equals(start))
+					{
+						var pathToEnd = childNode.GetPathToRoot();
+						if (RepairReversePath != null)
+							RepairReversePath(pathToEnd);
+
+						return pathToEnd;
+					}
+
 					if (!explored.Contains(childNode) && !reverseFrontier.Contains(childNode))
 						reverseFrontier.Enqueue(childNode);
 				}
@@ -148,7 +163,7 @@ namespace Tools.Algorithms.Search {
 			var nodeOnForwardPath = matchingNodes.Item1;
 			var nodeOnReversePath = matchingNodes.Item2;
 			var pathFromStart = nodeOnForwardPath.GetPath();
-			var pathToEnd = nodeOnReversePath.GetPath().Reverse();
+			var pathToEnd = nodeOnReversePath.GetPathToRoot();
 
 			if (RepairReversePath != null)
 				RepairReversePath(pathToEnd);

--- a/src/Search/BidirectionalSearch.cs
+++ b/src/Search/BidirectionalSearch.cs
@@ -68,74 +68,53 @@ namespace Tools.Algorithms.Search {
 			if (start.Equals(end))
 				return new T[] { start };
 
-			var startNode = new PathNode<T>(start);
-			var endNode = new PathNode<T>(end);
-
 			var forwardFrontier = new Queue<PathNode<T>>();
 			var reverseFrontier = new Queue<PathNode<T>>();
 			var explored = new HashSet<PathNode<T>>();
 
-			// Pre-load the frontiers of the start and end states
-			foreach (T child in GetForwardChildren(start))
-			{
-				var childNode = new PathNode<T>(child, startNode);
-				if (child.Equals(end)) // check here if start and end are connected
-					return childNode.GetPath();
-				else
-					forwardFrontier.Enqueue(childNode);
-			}
-
-			foreach (T child in GetReverseChildren(end))
-			{
-				reverseFrontier.Enqueue(new PathNode<T>(child, endNode));
-			}
-
-			explored.Add(startNode);
-			explored.Add(endNode);
+			forwardFrontier.Enqueue(new PathNode<T>(start));
+			reverseFrontier.Enqueue(new PathNode<T>(end));
 
 			while (forwardFrontier.Count > 0 && reverseFrontier.Count > 0)
 			{
+				forwardFrontier = GetNextLayer(forwardFrontier, explored, GetForwardChildren);
 				var match = FindMatchingNodes(forwardFrontier, reverseFrontier);
 				if (match != null)
 					return ConstructSolution(match);
 
-				PathNode<T> forwardNode = forwardFrontier.Dequeue();
-				explored.Add(forwardNode);
-				foreach (T child in GetForwardChildren(forwardNode.State))
-				{
-					var childNode = new PathNode<T>(child, forwardNode);
-					if (childNode.Equals(end))
-						return childNode.GetPath();
-
-					if (!explored.Contains(childNode) && !forwardFrontier.Contains(childNode))
-						forwardFrontier.Enqueue(childNode);
-				}
-
+				reverseFrontier = GetNextLayer(reverseFrontier, explored, GetReverseChildren);
 				match = FindMatchingNodes(forwardFrontier, reverseFrontier);
 				if (match != null)
 					return ConstructSolution(match);
-
-				PathNode<T> reverseNode = reverseFrontier.Dequeue();
-				explored.Add(reverseNode);
-				foreach (T child in GetReverseChildren(reverseNode.State))
-				{
-					var childNode = new PathNode<T>(child, reverseNode);
-					if (childNode.Equals(start))
-					{
-						var pathToEnd = childNode.GetPathToRoot();
-						if (RepairReversePath != null)
-							RepairReversePath(pathToEnd);
-
-						return pathToEnd;
-					}
-
-					if (!explored.Contains(childNode) && !reverseFrontier.Contains(childNode))
-						reverseFrontier.Enqueue(childNode);
-				}
 			}
 
 			// Path not found
-			return null;
+			return new T[] { };
+		}
+
+		private static Queue<PathNode<T>> GetNextLayer(
+			Queue<PathNode<T>> currentLayer,
+			HashSet<PathNode<T>> explored,
+			ChildGenerator<T> getChildren)
+		{
+			var nextLayer = new Queue<PathNode<T>>();
+			foreach (var currentNode in currentLayer)
+			{
+				explored.Add(currentNode);
+
+				foreach (var child in getChildren(currentNode.State))
+				{
+					var childNode = new PathNode<T>(child, currentNode);
+					if (!explored.Contains(childNode) &&
+						!currentLayer.Contains(childNode) &&
+						!nextLayer.Contains(childNode))
+					{
+						nextLayer.Enqueue(childNode);
+					}
+				}
+			}
+
+			return nextLayer;
 		}
 
 		private static Tuple<PathNode<T>, PathNode<T>> FindMatchingNodes(
@@ -151,7 +130,7 @@ namespace Tools.Algorithms.Search {
 				foreach (var reverseNode in reverseFrontier)
 				{
 					if (reverseNode.Equals(forwardNode))
-						return new Tuple<PathNode<T>, PathNode<T>>(forwardNode, reverseNode);
+						return Tuple.Create(forwardNode, reverseNode);
 				}
 			}
 

--- a/src/Search/BreadthFirstSearch.cs
+++ b/src/Search/BreadthFirstSearch.cs
@@ -20,8 +20,10 @@ namespace Tools.Algorithms.Search {
 
 		public IEnumerable<T> FindPath(T start, T end)
 		{
-			if (start == null || end == null)
-				return null;
+			if (start == null)
+				throw new ArgumentNullException("start");
+			if (end == null)
+				throw new ArgumentNullException("end");
 
 			PathNode<T> terminalNode = FindNode(start, node => node.Equals(end));
 			if (terminalNode == null)
@@ -33,16 +35,16 @@ namespace Tools.Algorithms.Search {
 		public PathNode<T> FindNode(
 			T start,
 			NodePredicate<T> nodePredicate,
-			uint maxSearchDistance = uint.MaxValue)
+			uint maxSearchDistance = uint.MaxValue - 1)
 		{
 			if (nodePredicate == null)
 				throw new ArgumentNullException("nodePredicate");
-			else if (maxSearchDistance == 0)
-				return null;
 
 			var startNode = new PathNode<T>(start);
 			if (nodePredicate(startNode))
 				return startNode;
+			else if (maxSearchDistance == 0)
+				return null;
 
 			var frontier = new Queue<PathNode<T>>();
 			var explored = new HashSet<PathNode<T>>();
@@ -59,7 +61,7 @@ namespace Tools.Algorithms.Search {
 					{
 						if (nodePredicate(childNode))
 							return childNode;
-						else if (childNode.CumulativePathLength < maxSearchDistance)
+						else if (childNode.CumulativePathLength < maxSearchDistance + 1)
 							frontier.Enqueue(childNode);
 					}
 				}

--- a/src/Search/DepthFirstSearch.cs
+++ b/src/Search/DepthFirstSearch.cs
@@ -21,16 +21,16 @@ namespace Tools.Algorithms.Search {
 		public PathNode<T> FindNode(
 			T start,
 			NodePredicate<T> nodePredicate,
-			uint maxSearchDistance = uint.MaxValue)
+			uint maxSearchDistance = uint.MaxValue - 1)
 		{
 			if (nodePredicate == null)
 				throw new ArgumentNullException("nodePredicate");
-			else if (maxSearchDistance == 0)
-				return null;
 
 			var startNode = new PathNode<T>(start);
 			if (nodePredicate(startNode))
 				return startNode;
+			else if (maxSearchDistance == 0)
+				return null;
 
 			var frontier = new Stack<PathNode<T>>();
 			var explored = new HashSet<PathNode<T>>();
@@ -47,7 +47,7 @@ namespace Tools.Algorithms.Search {
 					{
 						if (nodePredicate(childNode))
 							return childNode;
-						else if (childNode.CumulativePathLength < maxSearchDistance)
+						else if (childNode.CumulativePathLength < maxSearchDistance + 1)
 							frontier.Push(childNode);
 					}
 				}

--- a/src/Search/FlexibleBacktrackingSearch.cs
+++ b/src/Search/FlexibleBacktrackingSearch.cs
@@ -27,11 +27,10 @@ namespace Tools.Algorithms.Search {
 		/// <param name="getChildren">generates child states</param>
 		/// <param name="assumeChildrenNotInPath">if true, the algorithm will not check
 		/// whether each child is already in the current path. BEWARE: This is a performance
-		/// optimization for special cases. The algorithm is always correct when this is set
-		/// to false.</param>
+		/// optimization for special cases. If in doubt, leave this false.</param>
 		public FlexibleBacktrackingSearch(
 			ChildGenerator<T> getChildren,
-			bool assumeChildrenNotInPath = true)
+			bool assumeChildrenNotInPath = false)
 		{
 			if (getChildren == null)
 				throw new ArgumentNullException("getChildren");

--- a/src/Search/LeastWeightPathSearch.cs
+++ b/src/Search/LeastWeightPathSearch.cs
@@ -7,9 +7,8 @@ namespace Tools.Algorithms.Search {
 
 	/*
 	 * Least-weight path search (a.k.a. uniform cost search) explores nodes
-	 * in order by ascending cumulative path weight. It can find the optimal
-	 * (i.e. least-total-weight) path between two nodes in a graph with no
-	 * negative cycles.
+	 * in order by ascending cumulative path weight, allowing it to find the
+	 * least-total-weight path between two nodes.
 	 */
 	public class LeastWeightPathSearch<T>
 	{
@@ -31,8 +30,10 @@ namespace Tools.Algorithms.Search {
 
 		public IEnumerable<T> FindPath(T start, T end)
 		{
-			if (start == null || end == null)
-				return null;
+			if (start == null)
+				throw new ArgumentNullException("start");
+			if (end == null)
+				throw new ArgumentNullException("end");
 
 			PathNode<T> terminalNode = FindNode(start, node => node.Equals(end));
 			if (terminalNode == null)
@@ -44,12 +45,10 @@ namespace Tools.Algorithms.Search {
 		public PathNode<T> FindNode(
 			T start,
 			NodePredicate<T> nodePredicate,
-			uint maxSearchDistance = uint.MaxValue)
+			uint maxSearchDistance = uint.MaxValue - 1)
 		{
 			if (nodePredicate == null)
 				throw new ArgumentNullException("nodePredicate");
-			else if (maxSearchDistance == 0)
-				return null;
 
 			var frontier = BinaryHeap<PathNode<T>>.CreateMinFirstHeap();
 			var explored = new HashSet<PathNode<T>>();
@@ -60,7 +59,7 @@ namespace Tools.Algorithms.Search {
 				PathNode<T> currentNode = frontier.Dequeue().Value;
 				if (nodePredicate(currentNode))
 					return currentNode;
-				else if (currentNode.CumulativePathLength >= maxSearchDistance)
+				else if (currentNode.CumulativePathLength >= maxSearchDistance + 1)
 					continue;
 
 				explored.Add(currentNode);

--- a/src/Search/PathNode.cs
+++ b/src/Search/PathNode.cs
@@ -14,9 +14,9 @@ namespace Tools.Algorithms.Search {
 	public class PathNode<T>
 	{
 		public readonly T State;
-		public PathNode<T> Parent { get; private set; }
-		public uint CumulativePathLength { get; private set; }
-		public double CumulativePathWeight { get; private set; }
+		public readonly PathNode<T> Parent;
+		public readonly uint CumulativePathLength;
+		public readonly double CumulativePathWeight;
 
 		/*
 		 * Constructs a root node (the first node in a path).
@@ -27,7 +27,7 @@ namespace Tools.Algorithms.Search {
 		}
 
 		/*
-		 * Constructs a node with zero weight on the incoming edge.
+		 * Constructs a node with zero weight on its incoming edge.
 		 */
 		public PathNode(T state, PathNode<T> parent)
 			: this(state, parent, 0)
@@ -63,26 +63,17 @@ namespace Tools.Algorithms.Search {
 			get { return Parent == null; }
 		}
 
-		public PathNode<T> GetRoot()
-		{
-			PathNode<T> currentNode = this;
-			while (!currentNode.IsRoot)
-				currentNode = currentNode.Parent;
-
-			return currentNode;
-		}
-
 		public IEnumerable<T> GetPath()
 		{
-			return GetPathToRoot().Select(node => node.State).Reverse();
+			return GetPathToRoot().Reverse();
 		}
 
-		private IEnumerable<PathNode<T>> GetPathToRoot()
+		public IEnumerable<T> GetPathToRoot()
 		{
 			PathNode<T> currentNode = this;
 			while (currentNode != null)
 			{
-				yield return currentNode;
+				yield return currentNode.State;
 				currentNode = currentNode.Parent;
 			}
 		}
@@ -98,10 +89,19 @@ namespace Tools.Algorithms.Search {
 			return false;
 		}
 
+		public bool Equals(PathNode<T> node)
+		{
+			return node != null && State.Equals(node.State);
+		}
+
+		public bool Equals(T state)
+		{
+			return State.Equals(state);
+		}
+
 		public override bool Equals(object obj)
 		{
-			PathNode<T> other = obj as PathNode<T>;
-			return other != null && State.Equals(other.State);
+			return Equals(obj as PathNode<T>);
 		}
 
 		public override int GetHashCode()

--- a/src/Search/test/BidirectionalSearchUnitTests.cs
+++ b/src/Search/test/BidirectionalSearchUnitTests.cs
@@ -11,40 +11,177 @@ namespace Test {
 	public class BidirectionalSearchUnitTests
 	{
 		#region Constructor
+		[TestMethod]
+		public void Constructor_WithNullUndirectedChildGenerator_ThrowsArgumentNullException()
+		{
+			// Act
+			Action action = () =>
+			{
+				var bidi = new BidirectionalSearch<int>(null);
+			};
 
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void Constructor_WithNullForwardChildGenerator_ThrowsArgumentNullException()
+		{
+			// Act
+			Action action = () =>
+			{
+				var bidi = new BidirectionalSearch<int>(null, SearchTestHelpers.AnyChildGenerator);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void Constructor_WithNullReverseChildGenerator_ThrowsArgumentNullException()
+		{
+			// Act
+			Action action = () =>
+			{
+				var bidi = new BidirectionalSearch<int>(SearchTestHelpers.AnyChildGenerator, null);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
 		#endregion
 
+		#region FindPath
 		[TestMethod]
-		public void FindPath_PathsNeverMeetButEndIsOnPathFromStart_ReturnsPathFromStartToEnd()
+		public void FindPath_StartIsNull_ThrowsArgumentNullException()
 		{
 			// Arrange
-			var bidi = new BidirectionalSearch<int>(TestGraphs.BinaryTree());
+			var bidi = new BidirectionalSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			Action action = () =>
+			{
+				bidi.FindPath(null, "end");
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindPath_EndIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var bidi = new BidirectionalSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			Action action = () =>
+			{
+				bidi.FindPath("start", null);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindPath_StartEqualsEnd_ReturnsPathContainingStart()
+		{
+			// Arrange
+			var bidi = new BidirectionalSearch<string>(SearchTestHelpers.AnyChildGenerator);
+			string start = "foo";
+			string end = start;
+
+			// Act
+			var path = bidi.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new string[] { start };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+
+		[TestMethod]
+		public void FindPath_StartAndEndHaveNoChildren_ReturnsEmptyPath()
+		{
+			// Arrange
+			var bidi = new BidirectionalSearch<string>(TestGraphs.EdgelessGraph<string>());
+
+			// Act
+			var path = bidi.FindPath("start", "end");
+
+			// Assert
+			Assert.AreEqual(0, path.Count());
+		}
+
+		[TestMethod]
+		public void FindPath_StartAndEndAreNotConnectedAndGraphIsFinite_ReturnsEmptyPath()
+		{
+			// Arrange
+			var bidi = new BidirectionalSearch<int>(TestGraphs.FiniteGraph(6));
+			int start = -2;
+			int end = 5;
+
+			// Act
+			var path = bidi.FindPath(start, end);
+
+			// Assert
+			Assert.AreEqual(0, path.Count());
+		}
+
+		[TestMethod]
+		public void FindPath_EndIsInFrontierOfStart_ReturnsPathFromStartToEndOfLengthTwo()
+		{
+			// Arrange
+			var bidi = new BidirectionalSearch<int>(TestGraphs.OnePathGraph());
+			int start = 2;
+			int end = 3;
+
+			// Act
+			var path = bidi.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new int[] { start, end };
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
+		}
+
+		[TestMethod]
+		public void FindPath_StartAndEndAreConnected_ReturnsPathFromStartToEnd()
+		{
+			// Arrange
+			var bidi = new BidirectionalSearch<int>(
+				TestGraphs.TwoAsymmetricalPathsGraph(),
+				TestGraphs.ReverseTwoAsymmetricalPathsGraph());
 			int start = 1;
-			int end = 10;
+			int end = 7;
 
 			// Act
 			var path = bidi.FindPath(start, end);
 
 			// Assert
-			var expectedPath = new int[] { 1, 2, 5, 10 };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			var expectedPath = new int[] { 1, 3, 5, 7 };
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 
 		[TestMethod]
-		public void FindPath_PathsNeverMeetButStartIsOnPathFromEnd_ReturnsPathFromStartToEnd()
+		public void FindPath_StartAndEndAreConnectedAndRepairReversePathIsGiven_CallsRepairReversePathWithCorrectPath()
 		{
 			// Arrange
-			var bidi = new BidirectionalSearch<int>(TestGraphs.BinaryTree());
-			int start = 10;
-			int end = 1;
+			IEnumerable<int> actualReversePath = null;
+			var bidi = new BidirectionalSearch<int>(
+				TestGraphs.TwoAsymmetricalPathsGraph(),
+				TestGraphs.ReverseTwoAsymmetricalPathsGraph(),
+				(reversePath) => { actualReversePath = reversePath; });
+			int start = 1;
+			int end = 7;
 
 			// Act
 			var path = bidi.FindPath(start, end);
 
 			// Assert
-			var expectedPath = new int[] { 10, 5, 2, 1 };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			var expectedReversePath = new int[] { 5, 7 };
+			CollectionAssert.AreEqual(expectedReversePath, actualReversePath.ToList());
 		}
+		#endregion
 	};
 
 }

--- a/src/Search/test/BidirectionalSearchUnitTests.cs
+++ b/src/Search/test/BidirectionalSearchUnitTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Tools.Algorithms.Search;
+
+namespace Test {
+
+	[TestClass]
+	public class BidirectionalSearchUnitTests
+	{
+		#region Constructor
+
+		#endregion
+
+		[TestMethod]
+		public void FindPath_PathsNeverMeetButEndIsOnPathFromStart_ReturnsPathFromStartToEnd()
+		{
+			// Arrange
+			var bidi = new BidirectionalSearch<int>(TestGraphs.BinaryTree());
+			int start = 1;
+			int end = 10;
+
+			// Act
+			var path = bidi.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new int[] { 1, 2, 5, 10 };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+
+		[TestMethod]
+		public void FindPath_PathsNeverMeetButStartIsOnPathFromEnd_ReturnsPathFromStartToEnd()
+		{
+			// Arrange
+			var bidi = new BidirectionalSearch<int>(TestGraphs.BinaryTree());
+			int start = 10;
+			int end = 1;
+
+			// Act
+			var path = bidi.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new int[] { 10, 5, 2, 1 };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+	};
+
+}

--- a/src/Search/test/BreadthFirstSearchUnitTests.cs
+++ b/src/Search/test/BreadthFirstSearchUnitTests.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Tools.Algorithms.Search;
+
+namespace Test {
+
+	[TestClass]
+	public class BreadthFirstSearchUnitTests
+	{
+		#region Constructor
+		[TestMethod]
+		public void Constructor_WithNullChildGenerator_ThrowsArgumentNullException()
+		{
+			// Act
+			Action action = () =>
+			{
+				var bfs = new BreadthFirstSearch<int>(null);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+		#endregion
+
+		#region FindPath
+		[TestMethod]
+		public void FindPath_StartIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			Action action = () =>
+			{
+				bfs.FindPath(null /*start*/, "end");
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindPath_EndIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			Action action = () =>
+			{
+				bfs.FindPath("start", null /*end*/);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindPath_StartEqualsEnd_ReturnsPathContainingStart()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+			string start = "foo";
+			string end = start;
+
+			// Act
+			var path = bfs.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new string[] { start };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+
+		[TestMethod]
+		public void FindPath_StartHasNoChildren_ReturnsEmptyPath()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<string>(TestGraphs.EdgelessGraph<string>());
+
+			// Act
+			var path = bfs.FindPath("start", "end");
+
+			// Assert
+			Assert.AreEqual(0, path.Count());
+		}
+
+		[TestMethod]
+		public void FindPath_StartAndEndAreNotConnectedAndGraphIsFinite_ReturnsEmptyPath()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<int>(TestGraphs.FiniteGraph(13));
+			int start = 1;
+			int end = 14;
+
+			// Act
+			var path = bfs.FindPath(start, end);
+
+			// Assert
+			Assert.AreEqual(0, path.Count());
+		}
+
+		[TestMethod]
+		public void FindPath_StartAndEndAreConnected_ReturnsPathFromStartToEnd()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<int>(TestGraphs.OnePathGraph());
+			int start = 1;
+			int end = 4;
+
+			// Act
+			var path = bfs.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new int[] { 1, 2, 3, 4 };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+		#endregion
+
+		#region FindNode
+		[TestMethod]
+		public void FindNode_StartIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			Action action = () =>
+			{
+				bfs.FindNode(null /*start*/, SearchTestHelpers.AnyNodePredicate);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicateIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			Action action = () =>
+			{
+				bfs.FindNode("start", null /*nodePredicate*/);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindNode_MaxSearchDistanceIsZeroAndStartPassesPredicate_ReturnsStartNode()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+			string start = "foo";
+
+			// Act
+			var node = bfs.FindNode(start, n => true, 0);
+
+			// Assert
+			var expectedNode = new PathNode<string>(start);
+			Assert.AreEqual(expectedNode, node);
+		}
+
+		[TestMethod]
+		public void FindNode_MaxSearchDistanceIsZeroAndStartDoesNotPassPredicate_ReturnsNull()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			var node = bfs.FindNode("start", n => false, 0);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_StartHasNoChildrenAndDoesNotPassPredicate_ReturnsNull()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<string>(TestGraphs.EdgelessGraph<string>());
+
+			// Act
+			var node = bfs.FindNode("start", n => false);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicateNeverPassesAndGraphIsFinite_ReturnsNull()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<int>(TestGraphs.FiniteGraph(20));
+			int anyStart = 10;
+
+			// Act
+			var node = bfs.FindNode(anyStart, n => false);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicateWouldPassButPathIsLongerThanMaxSearchDistance_ReturnsNull()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<int>(TestGraphs.OnePathGraph());
+			int start = 1;
+			int end = 10;
+			uint maxSearchDistance = 8;
+
+			// Act
+			var node = bfs.FindNode(start, n => n.State == end, maxSearchDistance);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicatePasses_ReturnsNodeThatPassedPredicateWithPathLeadingToStart()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<int>(TestGraphs.OnePathGraph());
+			int start = 1;
+			int end = 4;
+
+			// Act
+			var node = bfs.FindNode(start, n => n.State == end);
+
+			// Assert
+			var expectedNode = new PathNode<int>(end);
+			Assert.AreEqual(expectedNode, node);
+
+			var expectedPath = new int[] { 1, 2, 3, 4 };
+			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+			Assert.AreEqual((uint)expectedPath.Length, node.CumulativePathLength);
+		}
+		#endregion
+
+		#region Special graphs
+		[TestMethod]
+		public void FindPath_GraphIsABinaryTree_FindsPathBetweenTwoNodes()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<int>(TestGraphs.BinaryTree());
+			int start = 1;
+			int end = 7;
+
+			// Act
+			var path = bfs.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new int[] { 1, 3, 7 };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+
+		[TestMethod]
+		public void FindPath_GraphIsACycleContainingEnd_FindsPathFromStartToEnd()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<int>(TestGraphs.OneCycleGraph(8));
+			int start = 1;
+			int end = 5;
+
+			// Act
+			var path = bfs.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new int[] { 1, 2, 3, 4, 5 };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+
+		[TestMethod]
+		public void FindPath_GraphIsACycleNotContainingEnd_ReturnsEmptyPath()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<int>(TestGraphs.OneCycleGraph(8));
+			int start = 3;
+			int end = 9;
+
+			// Act
+			var path = bfs.FindPath(start, end);
+
+			// Assert
+			Assert.AreEqual(0, path.Count());
+		}
+
+		[TestMethod]
+		public void FindPath_GraphHasTwoPathsFromStartToEnd_ReturnsShorterPath()
+		{
+			// Arrange
+			var bfs = new BreadthFirstSearch<int>(TestGraphs.TwoAsymmetricalPathsGraph());
+			int start = 1;
+			int end = 7;
+
+			// Act
+			var path = bfs.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new int[] { 1, 3, 5, 7 };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+		#endregion
+	};
+
+}

--- a/src/Search/test/DepthFirstSearchUnitTests.cs
+++ b/src/Search/test/DepthFirstSearchUnitTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Tools.Algorithms.Search;
+
+namespace Test {
+
+	[TestClass]
+	public class DepthFirstSearchUnitTests
+	{
+		#region Constructor
+		[TestMethod]
+		public void Constructor_WithNullChildGenerator_ThrowsArgumentNullException()
+		{
+			// Act
+			Action action = () =>
+			{
+				var dfs = new DepthFirstSearch<int>(null /*getChildren*/);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+		#endregion
+
+		#region FindNode
+		[TestMethod]
+		public void FindNode_StartIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			Action action = () =>
+			{
+				dfs.FindNode(null /*start*/, SearchTestHelpers.AnyNodePredicate);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicateIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			Action action = () =>
+			{
+				dfs.FindNode("start", null /*nodePredicate*/);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindNode_MaxSearchDistanceIsZeroAndStartPassesPredicate_ReturnsStartNode()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+			string start = "foo";
+
+			// Act
+			var node = dfs.FindNode(start, n => true, 0);
+
+			// Assert
+			var expectedNode = new PathNode<string>(start);
+			Assert.AreEqual(expectedNode, node);
+		}
+
+		[TestMethod]
+		public void FindNode_MaxSearchDistanceIsZeroAndStartDoesNotPassPredicate_ReturnsNull()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<string>(SearchTestHelpers.AnyChildGenerator);
+
+			// Act
+			var node = dfs.FindNode("start", n => false, 0);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_StartHasNoChildrenAndDoesNotPassPredicate_ReturnsNull()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<string>(TestGraphs.EdgelessGraph<string>());
+
+			// Act
+			var node = dfs.FindNode("start", n => false);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicateNeverPassesAndGraphIsFinite_ReturnsNull()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<int>(TestGraphs.FiniteGraph(21));
+			int start = 13;
+
+			// Act
+			var node = dfs.FindNode(start, n => false);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicateWouldPassButPathIsLongerThanMaxSearchDistance_ReturnsNull()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<int>(TestGraphs.OnePathGraph());
+			int start = 3;
+			int end = 15;
+			uint maxSearchDistance = 11;
+
+			// Act
+			var node = dfs.FindNode(start, n => n.State == end, maxSearchDistance);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicatePasses_ReturnsNodeThatPassedPredicateWithPathLeadingToStart()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<int>(TestGraphs.OnePathGraph());
+			int start = 12;
+			int end = 15;
+
+			// Act
+			var node = dfs.FindNode(start, n => n.State == end);
+
+			// Assert
+			var expectedNode = new PathNode<int>(end);
+			Assert.AreEqual(expectedNode, node);
+
+			var expectedPath = new int[] { 12, 13, 14, 15 };
+			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+			Assert.AreEqual((uint)expectedPath.Length, node.CumulativePathLength);
+		}
+		#endregion
+
+		#region Special graphs
+		[TestMethod]
+		public void FindNode_GraphIsABinaryTree_ReturnsNodeOnExpectedPath()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<int>(TestGraphs.BinaryTree());
+			int start = 1;
+			int end = 7;
+
+			// Act
+			var node = dfs.FindNode(start, n => n.State == end);
+
+			// Assert
+			var expectedNode = new PathNode<int>(end);
+			Assert.AreEqual(expectedNode, node);
+
+			var expectedPath = new int[] { 1, 3, 7 };
+			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+		}
+
+		[TestMethod]
+		public void FindNode_GraphIsACycleAndNodePredicatePasses_ReturnsNodeThatPassedPredicate()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<int>(TestGraphs.OneCycleGraph(6));
+			int start = 4;
+			int end = 2;
+
+			// Act
+			var node = dfs.FindNode(start, n => n.State == end);
+
+			// Assert
+			var expectedNode = new PathNode<int>(end);
+			Assert.AreEqual(expectedNode, node);
+
+			var expectedPath = new int[] { 4, 5, 0, 1, 2 };
+			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+		}
+
+		[TestMethod]
+		public void FindNode_GraphIsACycleAndNodePredicateDoesNotPass_ReturnsNull()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<int>(TestGraphs.OneCycleGraph(4));
+			int start = 2;
+
+			// Act
+			var node = dfs.FindNode(start, n => false);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_GraphsHasTwoPathsFromStartToTargetNode_ReturnsNodeOnFirstPathExplored()
+		{
+			// Arrange
+			var dfs = new DepthFirstSearch<int>(TestGraphs.TwoAsymmetricalPathsGraph());
+			int start = 1;
+			int end = 7;
+
+			// Act
+			var node = dfs.FindNode(start, n => n.State == end);
+
+			// Assert
+			var expectedNode = new PathNode<int>(end);
+			Assert.AreEqual(expectedNode, node);
+
+			var expectedPath = new int[] { 1, 2, 4, 6, 7 };
+			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+		}
+		#endregion
+	}
+
+}

--- a/src/Search/test/LeastWeightPathSearchUnitTests.cs
+++ b/src/Search/test/LeastWeightPathSearchUnitTests.cs
@@ -1,0 +1,395 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Tools.Algorithms.Search;
+
+namespace Test {
+
+	[TestClass]
+	public class LeastWeightPathSearchUnitTests
+	{
+		#region Constructor
+		private void Constructor_WithNullArgument_ThrowsArgumentNullException(
+			ChildGenerator<int> getChildren,
+			EdgeWeightCalculator<int> getEdgeWeight)
+		{
+			// Act
+			Action action = () =>
+			{
+				var lwps = new LeastWeightPathSearch<int>(getChildren, getEdgeWeight);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void Constructor_WithNullChildGenerator_ThrowsArgumentNullException()
+		{
+			Constructor_WithNullArgument_ThrowsArgumentNullException(
+				null,
+				AnyEdgeWeightCalculator);
+		}
+
+		[TestMethod]
+		public void Constructor_WithNullEdgeWeightCalculator_ThrowsArgumentNullException()
+		{
+			Constructor_WithNullArgument_ThrowsArgumentNullException(
+				SearchTestHelpers.AnyChildGenerator,
+				null);
+		}
+		#endregion
+
+		#region FindPath
+		[TestMethod]
+		public void FindPath_StartIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var lwps = AnyLWPS<string>();
+
+			// Act
+			Action action = () =>
+			{
+				lwps.FindPath(null /*start*/, "end");
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindPath_EndIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var lwps = AnyLWPS<string>();
+
+			// Act
+			Action action = () =>
+			{
+				lwps.FindPath("start", null /*end*/);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindPath_StartEqualsEnd_ReturnsPathContainingStart()
+		{
+			// Arrange
+			var lwps = AnyLWPS<string>();
+			string start = "foo";
+			string end = start;
+
+			// Act
+			var path = lwps.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new string[] { start };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+
+		[TestMethod]
+		public void FindPath_StartHasNoChildren_ReturnsEmptyPath()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<string>(
+				TestGraphs.EdgelessGraph<string>(),
+				AnyEdgeWeightCalculator);
+
+			// Act
+			var path = lwps.FindPath("start", "end");
+
+			// Assert
+			Assert.AreEqual(0, path.Count());
+		}
+
+		[TestMethod]
+		public void FindPath_StartAndEndAreNotConnectedAndGraphIsFinite_ReturnsEmptyPath()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<int>(
+				TestGraphs.FiniteGraph(10),
+				AnyEdgeWeightCalculator);
+			int start = 0;
+			int end = 20;
+
+			// Act
+			var path = lwps.FindPath(start, end);
+
+			// Assert
+			Assert.AreEqual(0, path.Count());
+		}
+
+		[TestMethod]
+		public void FindPath_StartAndEndAreConnected_ReturnsPathFromStartToEnd()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<int>(
+				TestGraphs.OnePathGraph(),
+				AnyEdgeWeightCalculator);
+			int start = 0;
+			int end = 9;
+
+			// Act
+			var path = lwps.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+
+		[TestMethod]
+		public void FindPath_StartAndEndAreConnectedByTwoPathsWithDifferentWeight_ReturnsPathWithLessWeight()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<int>(
+				TestGraphs.TwoAsymmetricalPathsGraph(),
+				(int parent, int child) =>
+				{
+					// Give the even path (which is also the longer path in this graph)
+					// less weight.
+					if (child % 2 == 0)
+						return 0.49;
+					else
+						return 0.75;
+				});
+			int start = 1;
+			int end = 7;
+
+			// Act
+			var path = lwps.FindPath(start, end);
+
+			// Assert
+			var expectedPath = new int[] { 1, 2, 4, 6, 7 };
+			Assert.IsTrue(expectedPath.SequenceEqual(path));
+		}
+		#endregion
+
+		#region FindNode
+		[TestMethod]
+		public void FindNode_StartIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var lwps = AnyLWPS<string>();
+
+			// Act
+			Action action = () =>
+			{
+				lwps.FindNode(null /*start*/, SearchTestHelpers.AnyNodePredicate);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicateIsNull_ThrowsArgumentNullException()
+		{
+			// Arrange
+			var lwps = AnyLWPS<string>();
+
+			// Act
+			Action action = () =>
+			{
+				lwps.FindNode("start", null /*nodePredicate*/);
+			};
+
+			// Assert
+			Assert.ThrowsException<ArgumentNullException>(action);
+		}
+
+		[TestMethod]
+		public void FindNode_MaxSearchDistanceIsZeroAndStartPassesPredicate_ReturnsStartNode()
+		{
+			// Arrange
+			var lwps = AnyLWPS<string>();
+			string start = "foo";
+
+			// Act
+			var node = lwps.FindNode(start, n => true, 0);
+
+			// Assert
+			var expectedNode = new PathNode<string>(start);
+			Assert.AreEqual(expectedNode, node);
+		}
+
+		[TestMethod]
+		public void FindNode_MaxSearchDistanceIsZeroAndStartDoesNotPassPredicate_ReturnsNull()
+		{
+			// Arrange
+			var lwps = AnyLWPS<string>();
+
+			// Act
+			var node = lwps.FindNode("start", n => false, 0);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_StartHasNoChildrenAndDoesNotPassPredicate_ReturnsNull()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<string>(
+				TestGraphs.EdgelessGraph<string>(),
+				AnyEdgeWeightCalculator);
+
+			// Act
+			var node = lwps.FindNode("start", n => false);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicateNeverPassesAndGraphIsFinite_ReturnsNull()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<int>(
+				TestGraphs.FiniteGraph(3),
+				AnyEdgeWeightCalculator);
+			int start = 2;
+
+			// Act
+			var node = lwps.FindNode(start, n => false);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicateWouldPassButPathIsLongerThanMaxSearchDistance_ReturnsNull()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<int>(
+				TestGraphs.OnePathGraph(),
+				AnyEdgeWeightCalculator);
+			int start = -1;
+			int end = 7;
+			uint maxSearchDistance = 2;
+
+			// Act
+			var node = lwps.FindNode(start, n => n.State == end, maxSearchDistance);
+
+			// Assert
+			Assert.IsNull(node);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicatePasses_ReturnsNodeThatPassedPredicateWithPathLeadingToStart()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<int>(
+				TestGraphs.OnePathGraph(),
+				AnyEdgeWeightCalculator);
+			int start = -3;
+			int end = 0;
+
+			// Act
+			var node = lwps.FindNode(start, n => n.State == end);
+
+			// Assert
+			var expectedNode = new PathNode<int>(end);
+			Assert.AreEqual(expectedNode, node);
+
+			var expectedPath = new int[] { -3, -2, -1, 0 };
+			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+			Assert.AreEqual((uint)expectedPath.Length, node.CumulativePathLength);
+		}
+
+		[TestMethod]
+		public void FindNode_EdgesHaveNonzeroCostAndNodePredicatePasses_ReturnsNodeWithCorrectCumulativePathWeight()
+		{
+			// Arrange
+			double weight = 3.14;
+			var lwps = new LeastWeightPathSearch<int>(
+				TestGraphs.OnePathGraph(),
+				ConstantEdgeWeightCalculator<int>(weight));
+			int start = 0;
+			int end = 12;
+
+			// Act
+			var node = lwps.FindNode(start, n => n.State == end);
+
+			// Assert
+			double expectedTotalWeight = (end - start) * weight;
+			Assert.AreEqual(expectedTotalWeight, node.CumulativePathWeight);
+		}
+
+		[TestMethod]
+		public void FindNode_NodePredicatePassesForTwoNodesAtSameDistanceFromStartButDifferentWeights_ReturnsNodeOnPathWithLessWeight()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<int>(
+				TestGraphs.BinaryTree(),
+				(int parent, int child) =>
+				{
+					// Give odd nodes more weight
+					if (child == parent * 2)
+						return 1;
+					else
+						return 1.5;
+				});
+
+			// Act
+			// In a binary tree, nodes 8 and 9 are equidistant from the root
+			// (both are children of node 4).
+			var node = lwps.FindNode(1, n =>
+			{
+				return n.State == 8 || n.State == 9;
+			});
+
+			// Assert
+			var expectedNode = new PathNode<int>(8);
+			Assert.AreEqual(expectedNode, node);
+		}
+		#endregion
+
+		#region Special graphs
+		[TestMethod]
+		public void FindPath_GraphContainsNegativeCycleAndEndIsNotOnPath_ReturnsEmptyPath()
+		{
+			// Arrange
+			var lwps = new LeastWeightPathSearch<int>(
+				TestGraphs.OneCycleGraph(10),
+				(int parent, int child) =>
+				{
+					return -2; // negative edge weights
+				});
+
+			int start = 3;
+			int end = 100;
+
+			// Act
+			var path = lwps.FindPath(start, end);
+
+			// Assert
+			Assert.AreEqual(0, path.Count());
+		}
+		#endregion
+
+		private LeastWeightPathSearch<T> AnyLWPS<T>()
+		{
+			return new LeastWeightPathSearch<T>(
+				SearchTestHelpers.AnyChildGenerator,
+				AnyEdgeWeightCalculator);
+		}
+
+		private static double AnyEdgeWeightCalculator<T>(T parent, T child)
+		{
+			return 0;
+		}
+
+		private static EdgeWeightCalculator<T> ConstantEdgeWeightCalculator<T>(double weight)
+		{
+			return (T parent, T child) =>
+			{
+				return weight;
+			};
+		}
+	};
+
+}

--- a/src/Search/test/SearchComponentTests.cs
+++ b/src/Search/test/SearchComponentTests.cs
@@ -5,8 +5,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Tools.Algorithms.Search;
 
-namespace Test
-{
+namespace Test {
+
 	[TestClass]
 	public class SearchComponentTests
 	{

--- a/src/Search/test/SearchTestHelpers.cs
+++ b/src/Search/test/SearchTestHelpers.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+using Tools.Algorithms.Search;
+
+namespace Test {
+
+	public static class SearchTestHelpers
+	{
+		public static IEnumerable<T> AnyChildGenerator<T>(T state)
+		{
+			yield return default(T);
+		}
+
+		public static bool AnyNodePredicate<T>(PathNode<T> node)
+		{
+			return true;
+		}
+	}
+
+}

--- a/src/Search/test/TestGraphs.cs
+++ b/src/Search/test/TestGraphs.cs
@@ -92,6 +92,33 @@ namespace Test {
 				}
 			};
 		}
+
+		/*
+		 * Same as above, but the reverse child generator.
+		 */
+		public static ChildGenerator<int> ReverseTwoAsymmetricalPathsGraph()
+		{
+			return state =>
+			{
+				switch (state)
+				{
+					case 7:
+						return new int[] { 5, 6 };
+					case 6:
+						return new int[] { 4 };
+					case 5:
+						return new int[] { 3 };
+					case 4:
+						return new int[] { 2 };
+					case 3:
+						return new int[] { 1 };
+					case 2:
+						return new int[] { 1 };
+					default:
+						return new int[] { };
+				}
+			};
+		}
 	};
 
 }

--- a/src/Search/test/TestGraphs.cs
+++ b/src/Search/test/TestGraphs.cs
@@ -1,0 +1,97 @@
+using Tools.Algorithms.Search;
+
+namespace Test {
+
+	public static class TestGraphs
+	{
+		public static ChildGenerator<T> EdgelessGraph<T>()
+		{
+			return state =>
+			{
+				return new T[] { };
+			};
+		}
+
+		/*
+		 * 1 -- 2 -- 3 -- ...
+		 */
+		public static ChildGenerator<int> OnePathGraph()
+		{
+			return state =>
+			{
+				return new int[] { state + 1 };
+			};
+		}
+
+		/*
+		 * 1 -- 2 -- 3 -- ... -- maxState
+		 */
+		public static ChildGenerator<int> FiniteGraph(int maxState)
+		{
+			return state =>
+			{
+				if (state < maxState)
+					return new int[] { state + 1 };
+				else
+					return new int[] { };
+			};
+		}
+
+		/*
+		 *		1
+		 *	  2   3
+		 *	 4 5 6 7
+		 */
+		public static ChildGenerator<int> BinaryTree()
+		{
+			return state =>
+			{
+				return new int[] { state * 2, state * 2 + 1 };
+			};
+		}
+
+		/*
+		 * 1 ------ 4
+		 *  \	   /
+		 *   2 -- 3
+		 */
+		public static ChildGenerator<int> OneCycleGraph(int cycleLength)
+		{
+			return state =>
+			{
+				return new int[] { (state + 1) % cycleLength };
+			};
+		}
+
+		/*
+		 *   2 -- 4 -- 6
+		 *  /			\
+		 * 1			 7   Not a cyle (graph is directed from left to right)
+		 *  \			/
+		 *   3 ------- 5
+		 */
+		public static ChildGenerator<int> TwoAsymmetricalPathsGraph()
+		{
+			return state =>
+			{
+				switch (state)
+				{
+					case 1:
+						return new int[] { 3, 2 }; // order to make DFS interesting
+					case 2:
+						return new int[] { 4 };
+					case 3:
+						return new int[] { 5 };
+					case 4:
+						return new int[] { 6 };
+					case 5:
+					case 6:
+						return new int[] { 7 };
+					default:
+						return new int[] { };
+				}
+			};
+		}
+	};
+
+}


### PR DESCRIPTION
- Wrote unit tests for BFS, DFS, LWPS, and Bidi.
- Fixed a bug in Bidi where sub-optimal paths could be returned. This was due to not generating an entire frontier layer before checking for common nodes.
- Fixed bugs with `maxSearchDistance` in all of the aforementioned classes: the variable was being treated like a path length instead of a distance from the root.