### PR TITLE
Expanded use of CollectionAssert to assert equality of collections

### DIFF
--- a/src/Search/test/BidirectionalSearchUnitTests.cs
+++ b/src/Search/test/BidirectionalSearchUnitTests.cs
@@ -97,7 +97,7 @@ namespace Test {
 
 			// Assert
 			var expectedPath = new string[] { start };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 
 		[TestMethod]

--- a/src/Search/test/BreadthFirstSearchUnitTests.cs
+++ b/src/Search/test/BreadthFirstSearchUnitTests.cs
@@ -71,7 +71,7 @@ namespace Test {
 
 			// Assert
 			var expectedPath = new string[] { start };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 
 		[TestMethod]
@@ -115,7 +115,7 @@ namespace Test {
 
 			// Assert
 			var expectedPath = new int[] { 1, 2, 3, 4 };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 		#endregion
 
@@ -239,7 +239,7 @@ namespace Test {
 			Assert.AreEqual(expectedNode, node);
 
 			var expectedPath = new int[] { 1, 2, 3, 4 };
-			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+			CollectionAssert.AreEqual(expectedPath, node.GetPath().ToList());
 			Assert.AreEqual((uint)expectedPath.Length, node.CumulativePathLength);
 		}
 		#endregion
@@ -258,7 +258,7 @@ namespace Test {
 
 			// Assert
 			var expectedPath = new int[] { 1, 3, 7 };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 
 		[TestMethod]
@@ -274,7 +274,7 @@ namespace Test {
 
 			// Assert
 			var expectedPath = new int[] { 1, 2, 3, 4, 5 };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 
 		[TestMethod]
@@ -305,7 +305,7 @@ namespace Test {
 
 			// Assert
 			var expectedPath = new int[] { 1, 3, 5, 7 };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 		#endregion
 	};

--- a/src/Search/test/DepthFirstSearchUnitTests.cs
+++ b/src/Search/test/DepthFirstSearchUnitTests.cs
@@ -145,7 +145,7 @@ namespace Test {
 			Assert.AreEqual(expectedNode, node);
 
 			var expectedPath = new int[] { 12, 13, 14, 15 };
-			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+			CollectionAssert.AreEqual(expectedPath, node.GetPath().ToList());
 			Assert.AreEqual((uint)expectedPath.Length, node.CumulativePathLength);
 		}
 		#endregion
@@ -167,7 +167,7 @@ namespace Test {
 			Assert.AreEqual(expectedNode, node);
 
 			var expectedPath = new int[] { 1, 3, 7 };
-			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+			CollectionAssert.AreEqual(expectedPath, node.GetPath().ToList());
 		}
 
 		[TestMethod]
@@ -186,7 +186,7 @@ namespace Test {
 			Assert.AreEqual(expectedNode, node);
 
 			var expectedPath = new int[] { 4, 5, 0, 1, 2 };
-			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+			CollectionAssert.AreEqual(expectedPath, node.GetPath().ToList());
 		}
 
 		[TestMethod]
@@ -219,7 +219,7 @@ namespace Test {
 			Assert.AreEqual(expectedNode, node);
 
 			var expectedPath = new int[] { 1, 2, 4, 6, 7 };
-			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+			CollectionAssert.AreEqual(expectedPath, node.GetPath().ToList());
 		}
 		#endregion
 	}

--- a/src/Search/test/LeastWeightPathSearchUnitTests.cs
+++ b/src/Search/test/LeastWeightPathSearchUnitTests.cs
@@ -88,7 +88,7 @@ namespace Test {
 
 			// Assert
 			var expectedPath = new string[] { start };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 
 		[TestMethod]
@@ -138,7 +138,7 @@ namespace Test {
 
 			// Assert
 			var expectedPath = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 
 		[TestMethod]
@@ -164,7 +164,7 @@ namespace Test {
 
 			// Assert
 			var expectedPath = new int[] { 1, 2, 4, 6, 7 };
-			Assert.IsTrue(expectedPath.SequenceEqual(path));
+			CollectionAssert.AreEqual(expectedPath, path.ToList());
 		}
 		#endregion
 
@@ -296,7 +296,7 @@ namespace Test {
 			Assert.AreEqual(expectedNode, node);
 
 			var expectedPath = new int[] { -3, -2, -1, 0 };
-			Assert.IsTrue(expectedPath.SequenceEqual(node.GetPath()));
+			CollectionAssert.AreEqual(expectedPath, node.GetPath().ToList());
 			Assert.AreEqual((uint)expectedPath.Length, node.CumulativePathLength);
 		}
 

--- a/src/Search/test/SearchComponentTests.cs
+++ b/src/Search/test/SearchComponentTests.cs
@@ -34,7 +34,7 @@ namespace Test {
 			var actualPath = finalNode.GetPath().Select(city => city.Name);
 
 			// Assert
-			Assert.IsTrue(expectedPath.SequenceEqual(actualPath), "The expected and actual sequences should match.");
+			CollectionAssert.AreEqual(expectedPath, actualPath.ToList());
 		}
 
 		[TestMethod]
@@ -52,7 +52,7 @@ namespace Test {
 			var actualPath = bidirectionalSearch.FindPath(start, end).Select(city => city.Name);
 
 			// Assert
-			Assert.IsTrue(expectedPath.SequenceEqual(actualPath), "The expected and actual sequences should match.");
+			CollectionAssert.AreEqual(expectedPath, actualPath.ToList());
 		}
 
 #region Helper classes


### PR DESCRIPTION
This fixes #19 

In several places, we were using `Assert.IsTrue` to assert that two `IEnumerables` matched each other (via the `SequenceEqual` extension method). That approach did not produce effective logging when tests failed. The `CollectionAssert` class does this much more gracefully.
