### PR TITLE
Fixed a performance issue with PathNode

### DIFF
--- a/src/Search/PathNode.cs
+++ b/src/Search/PathNode.cs
@@ -84,7 +84,7 @@ namespace Tools.Algorithms.Search {
 
 		public bool PathContains(T state)
 		{
-			foreach (var otherState in GetPath())
+			foreach (var otherState in GetPathToRoot())
 			{
 				if (otherState.Equals(state))
 					return true;


### PR DESCRIPTION
`PathNode.PathContains` was generating the entire path to the root before iterating to test for equality, lowering the performance in cases when the given state can be found near the beginning of the collection. I fixed this by using `GetPathToRoot` instead of `GetPath` (the latter contains a `Reverse` call on the path `IEnumerable`).