### PR TITLE
Cleaned up PrefixTreeDictionary and related classes

### DIFF
--- a/src/DataStructures/PrefixTreeDictionary.cs
+++ b/src/DataStructures/PrefixTreeDictionary.cs
@@ -87,16 +87,21 @@ namespace Tools.DataStructures {
 		}
 
 		/*
-		 * Traverses the path from node to the root, removing all leaf nodes that are
-		 * not the end of a word.
+		 * Traverses the path from a leaf node to the root, removing all leaf nodes
+		 * that are not the end of a word.
 		 */
 		private void Prune(PrefixTreeNode node)
 		{
-			while (!node.IsRoot && node.IsLeaf && !node.IsEndOfWord)
+			if (node.IsLeaf)
 			{
-				var parent = (PrefixTreeNode)node.Parent;
-				parent.RemoveChild(node.Character);
-				node = parent;
+				char childCharacterToRemove = node.Character;
+				while (!node.IsRoot && !node.IsEndOfWord && node.ChildrenCount <= 1)
+				{
+					childCharacterToRemove = node.Character;
+					node = (PrefixTreeNode)node.Parent;
+				}
+
+				node.RemoveChild(childCharacterToRemove);
 			}
 		}
 

--- a/src/DataStructures/PrefixTreeDictionaryVisitors.cs
+++ b/src/DataStructures/PrefixTreeDictionaryVisitors.cs
@@ -32,19 +32,20 @@ namespace Tools.DataStructures {
 		}
 
 		/// <summary>
-		/// Prints all words in the subtree rooted at a node
+		/// Prints all words in the subtree rooted at a node.
 		/// </summary>
-		/// <param name="item">the node</param>
-		public void Visit(IPrefixTreeNode item)
+		/// <param name="node">the node</param>
+		public void Visit(IPrefixTreeNode node)
 		{
-			CurrentString.Append(item.Character);
+			if (!node.IsRoot)
+				CurrentString.Append(node.Character);
 
-			if (item.IsEndOfWord)
+			if (node.IsEndOfWord)
 				OutputStream.WriteLine(CurrentString.ToString());
 
-			foreach (var child in item.Children)
+			foreach (var child in node.Children)
 			{
-				Visit(child);
+				child.Accept(this);
 			}
 
 			CurrentString.Length--;
@@ -53,7 +54,7 @@ namespace Tools.DataStructures {
 
 
 	/// <summary>
-	/// Counts nodes in a PrefixTreeDictionary
+	/// Counts nodes in a PrefixTreeDictionary.
 	/// </summary>
 	public class CountNodesVisitor : IVisitor<IPrefixTreeNode>
 	{
@@ -65,7 +66,7 @@ namespace Tools.DataStructures {
 		}
 
 		/// <summary>
-		/// Counts all nodes in the subtree rooted at a node
+		/// Counts all nodes in the subtree rooted at a node.
 		/// </summary>
 		/// <param name="item">the node</param>
 		public void Visit(IPrefixTreeNode item)
@@ -74,7 +75,7 @@ namespace Tools.DataStructures {
 
 			foreach (var child in item.Children)
 			{
-				Visit(child);
+				child.Accept(this);
 			}
 		}
 	}

--- a/src/DataStructures/PrefixTreeEnumerator.cs
+++ b/src/DataStructures/PrefixTreeEnumerator.cs
@@ -25,7 +25,7 @@ namespace Tools.DataStructures
 			WordBuilder = new StringBuilder(prefix);
 			NodeEnumeratorStack = new Stack<IEnumerator<IPrefixTreeNode>>();
 			NodeEnumeratorStack.Push(CurrentNode.Children.GetEnumerator());
-			CheckInitialPrefix = prefix.Length > 0;
+			CheckInitialPrefix = CurrentNode.IsEndOfWord;
 		}
 
 		public string Current
@@ -43,8 +43,7 @@ namespace Tools.DataStructures
 			if (CheckInitialPrefix)
 			{
 				CheckInitialPrefix = false;
-				if (CurrentNode.IsEndOfWord)
-					return true;
+				return true;
 			}
 
 			while (NodeEnumeratorStack.Count > 0)

--- a/src/DataStructures/PrefixTreeNode.cs
+++ b/src/DataStructures/PrefixTreeNode.cs
@@ -8,18 +8,26 @@ namespace Tools.DataStructures {
 		public bool IsEndOfWord { get; set; }
 		public bool IsRoot
 		{
-			get { return Parent == null; }
+			get { return _Parent == null; }
+		}
+		public int ChildrenCount
+		{
+			get { return _Children.Count; }
 		}
 		public bool IsLeaf
 		{
-			get { return _Children.Count == 0; }
+			get { return ChildrenCount == 0; }
+		}
+		public IPrefixTreeNode Parent
+		{
+			get { return _Parent; }
 		}
 		public IEnumerable<IPrefixTreeNode> Children
 		{
 			get { return _Children.Values; }
 		}
-		public IPrefixTreeNode Parent { get; }
 
+		private readonly PrefixTreeNode _Parent;
 		private readonly SortedList<char, PrefixTreeNode> _Children;
 
 		/*
@@ -33,7 +41,7 @@ namespace Tools.DataStructures {
 		public PrefixTreeNode(char character, PrefixTreeNode parent)
 		{
 			Character = character;
-			Parent = parent;
+			_Parent = parent;
 			IsEndOfWord = false;
 			_Children = new SortedList<char, PrefixTreeNode>();
 		}


### PR DESCRIPTION
- Updated `PrefixTreeDictionary.Prune` to only sever the child connection at the highest node that can be pruned.
- Updated the visitors to be true visitors (i.e. to use double dispatch). Also made `PrintWordsVisitor` ignore the root node's character.
- Cleaned up the logic slightly in `PrefixTreeEnumerator`.